### PR TITLE
Expect "Upgrading" during cluster creation

### DIFF
--- a/ccloud/resource_ccloud_kubernetes_v1.go
+++ b/ccloud/resource_ccloud_kubernetes_v1.go
@@ -329,7 +329,7 @@ func resourceCCloudKubernetesV1Create(d *schema.ResourceData, meta interface{}) 
 	// waiting for Running state
 	timeout := d.Timeout(schema.TimeoutCreate)
 	target := "Running"
-	pending := []string{"Pending", "Creating"}
+	pending := []string{"Pending", "Creating", "Upgrading"}
 	err = kubernikusWaitForClusterV1(klient, cluster.Name, target, pending, timeout)
 	if err != nil {
 		return kubernikusHandleErrorV1("Error waiting for running cluster state", err)


### PR DESCRIPTION
```
Error: Error waiting for running cluster state: unexpected state 'Upgrading', wanted target 'Running'. last error: %!s(<nil>)
```

Probably an error occurs, when a non-default k8s version is specified, e.g. `version = "1.11.9"`