### PR TITLE
Allow Smaller Cluster CIDRs

### DIFF
--- a/ccloud/resource_ccloud_kubernetes_v1.go
+++ b/ccloud/resource_ccloud_kubernetes_v1.go
@@ -67,7 +67,7 @@ func resourceCCloudKubernetesV1() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				Computed:     true,
-				ValidateFunc: validation.CIDRNetwork(8, 16),
+				ValidateFunc: validation.CIDRNetwork(8, 17),
 			},
 
 			"service_cidr": {


### PR DESCRIPTION
Required because we have some clusters with smaller cluster cidrs that can't be recreated. :/