### PR TITLE
[quota v1]: Add current project/domain scope autodetect

### DIFF
--- a/ccloud/data_source_ccloud_quota_domain_v1.go
+++ b/ccloud/data_source_ccloud_quota_domain_v1.go
@@ -21,7 +21,7 @@ func dataSourceCCloudQuotaDomainV1Deprecated() *schema.Resource {
 			},
 			"domain_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 		},
@@ -62,7 +62,7 @@ func dataSourceCCloudQuotaDomainV1() *schema.Resource {
 			},
 			"domain_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 		},

--- a/ccloud/data_source_ccloud_quota_project_v1.go
+++ b/ccloud/data_source_ccloud_quota_project_v1.go
@@ -21,12 +21,12 @@ func dataSourceCCloudQuotaProjectV1Deprecated() *schema.Resource {
 			},
 			"domain_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 			"project_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 			"bursting": {
@@ -83,12 +83,12 @@ func dataSourceCCloudQuotaProjectV1() *schema.Resource {
 			},
 			"domain_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 			"project_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 			"bursting": {

--- a/website/docs/d/quota_domain_v1.html.markdown
+++ b/website/docs/d/quota_domain_v1.html.markdown
@@ -13,13 +13,7 @@ Use this data source to read the Limes (Quota) Domain resources.
 ## Example Usage
 
 ```hcl
-data "openstack_identity_project_v3" "demo" {
-  name = "demo"
-}
-
-data "ccloud_quota_domain_v1" "quota" {
-  domain_id  = data.openstack_identity_project_v3.demo.domain_id
-}
+data "ccloud_quota_domain_v1" "quota" {}
 ```
 
 ## Argument Reference
@@ -29,8 +23,8 @@ The following arguments are supported:
 * `region` - (Optional) The region in which to obtain the Limes client. If
   omitted, the `region` argument of the provider is used.
 
-* `domain_id` – (Required) The ID of the domain to read the quota. Changing
-  this forces a new resource to be created.
+* `domain_id` – (Optional) The ID of the domain to read the quota. Defaults to
+  the current domain scope. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/d/quota_project_v1.html.markdown
+++ b/website/docs/d/quota_project_v1.html.markdown
@@ -13,14 +13,7 @@ Use this data source to read the Limes (Quota) Project resources.
 ## Example Usage
 
 ```hcl
-data "openstack_identity_project_v3" "demo" {
-  name = "demo"
-}
-
-data "ccloud_quota_project_v1" "quota" {
-  domain_id  = data.openstack_identity_project_v3.demo.domain_id
-  project_id = data.openstack_identity_project_v3.demo.id
-}
+data "ccloud_quota_project_v1" "quota" {}
 ```
 
 ## Argument Reference
@@ -30,11 +23,12 @@ The following arguments are supported:
 * `region` - (Optional) The region in which to obtain the Limes client. If
   omitted, the `region` argument of the provider is used.
 
-* `domain_id` – (Required) The ID of the domain to read the quota. Changing
-  this forces a new resource to be created.
+* `domain_id` – (Optional) The ID of the domain to read the quota. Defaults to
+  the current domain scope. Changing this forces a new resource to be created.
 
-* `project_id` - (Required) The ID of the project within the `domain_id` to
-  read the quota. Changing this forces a new resource to be created.
+* `project_id` - (Optional) The ID of the project within the `domain_id` to
+  read the quota. Defaults to the current project scope. Changing this forces a
+  new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/quota_domain_v1.html.markdown
+++ b/website/docs/r/quota_domain_v1.html.markdown
@@ -19,13 +19,7 @@ this resource.
 ## Example Usage
 
 ```hcl
-data "openstack_identity_project_v3" "demo" {
-  name = "demo"
-}
-
 resource "ccloud_quota_domain_v1" "quota" {
-  domain_id = data.openstack_identity_project_v3.demo.domain_id
-
   compute {
     instances = 8
     cores     = 32
@@ -90,8 +84,9 @@ The following arguments are supported:
   omitted, the `region` argument of the provider is used. Changing this forces
   a new resource to be created.
 
-* `domain_id` – (Required) The ID of the domain to manage the quota. Changing
-  this forces a new resource to be created.
+* `domain_id` – (Optional) The ID of the domain to manage the quota. Defaults
+  to the current domain scope. Changing this forces a new resource to be
+  created.
 
 * `compute` - (Optional) The list of compute resources quota. Consists of
   `cores`, `instances`, `ram` (Mebibytes), `server_groups` and

--- a/website/docs/r/quota_project_v1.html.markdown
+++ b/website/docs/r/quota_project_v1.html.markdown
@@ -19,14 +19,7 @@ this resource.
 ## Example Usage
 
 ```hcl
-data "openstack_identity_project_v3" "demo" {
-  name = "demo"
-}
-
 resource "ccloud_quota_project_v1" "quota" {
-  domain_id  = data.openstack_identity_project_v3.demo.domain_id
-  project_id = data.openstack_identity_project_v3.demo.id
-
   bursting {
     enabled = true
   }
@@ -95,11 +88,13 @@ The following arguments are supported:
   omitted, the `region` argument of the provider is used. Changing this forces
   a new resource to be created.
 
-* `domain_id` – (Required) The ID of the domain to manage the quota. Changing
-  this forces a new resource to be created.
+* `domain_id` – (Optional) The ID of the domain to manage the quota. Defaults
+  to the current domain scope. Changing this forces a new resource to be
+  created.
 
-* `project_id` - (Required) The ID of the project within the `domain_id` to
-  manage the quota. Changing this forces a new resource to be created.
+* `project_id` - (Optional) The ID of the project within the `domain_id` to
+  manage the quota. Defaults to the current project scope. Changing this forces
+  a new resource to be created.
 
 * `bursting` - (Optional) If bursting is enabled, the project may exceed its
   granted quota by a certain multiplier. In case the higher usage level becomes


### PR DESCRIPTION
This PR adds an automatic detection for quota `domain_id` and `project_id` from the current keystone token scope and make these fields optional.