### PR TITLE
Add support for system scope auth

### DIFF
--- a/ccloud/provider.go
+++ b/ccloud/provider.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/meta"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/utils/terraform/auth"
 	"github.com/gophercloud/utils/terraform/mutexkv"
 )
@@ -157,6 +158,13 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OS_DEFAULT_DOMAIN", "default"),
 				Description: descriptions["default_domain"],
+			},
+
+			"system_scope": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_SYSTEM_SCOPE", false),
+				Description: descriptions["system_scope"],
 			},
 
 			"insecure": {
@@ -332,6 +340,8 @@ func init() {
 
 		"default_domain": "The name of the Domain ID to scope to if no other domain is specified. Defaults to `default` (Identity v3).",
 
+		"system_scope": "If set to `true`, system scoped authorization will be enabled. Defaults to `false` (Identity v3).",
+
 		"insecure": "Trust self-signed certificates.",
 
 		"cacert_file": "A Custom CA certificate.",
@@ -370,6 +380,10 @@ func configureProvider(d *schema.ResourceData, terraformVersion string) (interfa
 		}
 	}
 
+	authOpts := &gophercloud.AuthOptions{
+		Scope: &gophercloud.AuthScope{System: d.Get("system_scope").(bool)},
+	}
+
 	config := Config{
 		auth.Config{
 			CACertFile:                  d.Get("cacert_file").(string),
@@ -398,6 +412,7 @@ func configureProvider(d *schema.ResourceData, terraformVersion string) (interfa
 			ApplicationCredentialSecret: d.Get("application_credential_secret").(string),
 			DelayedAuth:                 d.Get("delayed_auth").(bool),
 			AllowReauth:                 d.Get("allow_reauth").(bool),
+			AuthOpts:                    authOpts,
 			MaxRetries:                  d.Get("max_retries").(int),
 			DisableNoCacheHeader:        d.Get("disable_no_cache_header").(bool),
 			TerraformVersion:            terraformVersion,

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -128,6 +128,8 @@ The following arguments are supported:
   `OS_DEFAULT_DOMAIN` is checked or a default value of "default" will be
   used.
 
+* `system_scope` - (Optional) Set to `true` to enable system scoped authorization. If omitted, the `OS_SYSTEM_SCOPE` environment variable is used.
+
 * `insecure` - (Optional) Trust self-signed SSL certificates. If omitted, the
   `OS_INSECURE` environment variable is used.
 


### PR DESCRIPTION
Recent gophercloud dependency breaks compatibility with auth structure causing nil pointer dereference:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xa8 pc=0xdb5b98]

goroutine 69 [running]:
github.com/gophercloud/utils/terraform/auth.(*Config).LoadAndValidate(0xc0006c0b40)
        github.com/gophercloud/utils/terraform/auth/config.go:156 +0x738
```

this PR should fix the panic