### PR TITLE
[core]: add provider version to user-agent

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+      - '-s -w -X github.com/sapcc/terraform-provider-ccloud/ccloud.version={{.Version}}'
     goos:
       - freebsd
       - windows

--- a/ccloud/provider.go
+++ b/ccloud/provider.go
@@ -14,6 +14,8 @@ import (
 	"github.com/gophercloud/utils/v2/terraform/mutexkv"
 )
 
+var version = "dev"
+
 // Use openstackbase.Config as the base/foundation of this provider's
 // Config struct.
 type Config struct {
@@ -435,7 +437,7 @@ func configureProvider(ctx context.Context, d *schema.ResourceData, terraformVer
 			MaxRetries:                  d.Get("max_retries").(int),
 			DisableNoCacheHeader:        d.Get("disable_no_cache_header").(bool),
 			TerraformVersion:            terraformVersion,
-			SDKVersion:                  getSDKVersion(),
+			SDKVersion:                  getSDKVersion() + " Terraform Provider CCloud/" + version,
 			MutexKV:                     mutexkv.NewMutexKV(),
 			EnableLogger:                enableLogging,
 		},


### PR DESCRIPTION
This change will build a user-agent header like:

`
User-Agent: HashiCorp Terraform/1.6.6 (+https://www.terraform.io) Terraform Plugin SDK/2.34.0 Terraform Provider OpenStack/1.6.5 gophercloud/v2.0.0
`